### PR TITLE
add checksum check

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ await DashPhrase.decode(words);
 // Uint8Array[12] <0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255>
 ```
 
-### DashPhrase.toSeed(passphraseMnemonic, saltPassword)
+### DashPhrase.toSeed(passphraseMnemonic, saltPassword, { verify: true })
 
 Generate a private key seed or encryption key based on the passphrase (mnemonic
 word list) and some other string - whether a salt, a password, another
@@ -202,6 +202,8 @@ passphrase or secret, or an id of some kind.
 ```js
 await DashPhrase.toSeed(passphraseMnemonic, saltPassword || ""); // Uint8Array[64]
 ```
+
+If you'd like to skip the word and checksum checks, pass `{ verify: false }`.
 
 ### DashPhrase.base2048.includes(word)
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ the checksum does not match.
 ```js
 let words = "abstract way divert acid useless legend advance theme youth";
 
-await DashPhrase.decode(words);
+let entropy = await DashPhrase.decode(words);
 // Uint8Array[12] <0, 255, 0, 255, 0, 255, 0, 255, 0, 255, 0, 255>
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ Empty _secret salt_:
   - decode
 - toSeed
 - base2048.includes
+- Errors
+  - `E_UNKNOWN_WORD`
+  - `E_BAD_CHECKSUM`
 - CATMONIC
 - ZOOMONIC
 - ZECRET
@@ -225,6 +228,11 @@ DashPhrase.base2048.includes("brocolli"); // false
 });
 // [ "brocolli" ]
 ```
+
+### Errors
+
+- `E_UNKNOWN_WORD` - at least one the given words is not in the word list
+- `E_BAD_CHECKSUM` - words were good, but checksum failed
 
 ### DashPhrase.CATMONIC
 

--- a/dashphrase.js
+++ b/dashphrase.js
@@ -147,7 +147,12 @@ var Dashphrase = DashPhrase; // jshint ignore:line
     return bytes;
   };
 
-  DashPhrase.toSeed = async function (passphrase, salt = "") {
+  DashPhrase.toSeed = async function (passphrase, salt = "", opts) {
+    let shouldVerify = false !== opts?.verify;
+    if (shouldVerify) {
+      await DashPhrase.verify(passphrase);
+    }
+
     passphrase = DashPhrase._normalize(passphrase);
     salt = salt.normalize("NFKD");
 
@@ -300,5 +305,11 @@ if ("object" === typeof module) {
  * @callback PhraseToSeed
  * @param {string} passphrase - Same as from DashPhrase.generate(...).
  * @param {string} salt - Another passphrase (or whatever) to produce a pairwise key.
+ * @param {PhraseToSeedOptions} opts - verify is true by default
  * @returns {Promise<Uint8Array>} - A new key - the PBKDF2 of the passphrase + "mnemonic" + salt.
+ */
+
+/**
+ * @typedef PhraseToSeedOptions
+ * @prop {Boolean?} [verify]
  */

--- a/dashphrase.js
+++ b/dashphrase.js
@@ -88,7 +88,7 @@ var Dashphrase = DashPhrase; // jshint ignore:line
   };
 
   DashPhrase.verify = async function (passphrase) {
-    await DashPhrase.decode(passphrase);
+    void (await DashPhrase.decode(passphrase));
     return true;
   };
   DashPhrase.checksum = DashPhrase.verify;
@@ -139,9 +139,10 @@ var Dashphrase = DashPhrase; // jshint ignore:line
     }
 
     // the original random bytes used to generate the 12-24 words
-    let bytes = Uint8Array.from(bytesArr);
+    let entropyBytes = Uint8Array.from(bytesArr);
 
-    let hash = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+    let shaAb = await crypto.subtle.digest("SHA-256", entropyBytes);
+    let hash = new Uint8Array(shaAb);
     let expected = hash[0].toString(2).padStart(8, "0").slice(0, sumBitLen);
     if (expected !== checksum) {
       if (false !== opts?.verify) {
@@ -154,7 +155,7 @@ var Dashphrase = DashPhrase; // jshint ignore:line
       }
     }
 
-    return bytes;
+    return entropyBytes;
   };
 
   DashPhrase.toSeed = async function (passphrase, salt = "", opts = {}) {

--- a/dashphrase.js
+++ b/dashphrase.js
@@ -147,8 +147,8 @@ var Dashphrase = DashPhrase; // jshint ignore:line
     return bytes;
   };
 
-  DashPhrase.toSeed = async function (passphrase, salt = "", opts) {
-    let shouldVerify = false !== opts?.verify;
+  DashPhrase.toSeed = async function (passphrase, salt = "", opts = {}) {
+    let shouldVerify = false !== opts.verify;
     if (shouldVerify) {
       await DashPhrase.verify(passphrase);
     }

--- a/dashphrase.js
+++ b/dashphrase.js
@@ -107,9 +107,12 @@ var Dashphrase = DashPhrase; // jshint ignore:line
         // 0-2047 (11-bit ints)
         let index = DashPhrase.base2048.indexOf(word);
         if (index < 0) {
-          throw new Error(
+          let err = new Error(
             `dashphrase.js: decode failed: unknown word '${word}'`,
           );
+          //@ts-ignore - allow code on Error
+          err.code = "E_UNKNOWN_WORD";
+          throw err;
         }
         ints.push(index);
       },
@@ -142,9 +145,12 @@ var Dashphrase = DashPhrase; // jshint ignore:line
     let expected = hash[0].toString(2).padStart(8, "0").slice(0, sumBitLen);
     if (expected !== checksum) {
       if (false !== opts?.verify) {
-        throw new Error(
+        let err = new Error(
           `dashphrase.js: bad checksum: expected '${expected}' but got '${checksum}'`,
         );
+        //@ts-ignore
+        err.code = "E_BAD_CHECKSUM";
+        throw err;
       }
     }
 

--- a/dashphrase.js
+++ b/dashphrase.js
@@ -7,6 +7,10 @@
  * @prop {PhraseGenerate} generate
  * @prop {PhraseToSeed} toSeed
  * @prop {PhraseVerify} verify
+ * @prop {String} CATMONIC
+ * @prop {String} ZOOMONIC
+ * @prop {String} ZECRET
+ * @prop {String} ZEED
  * @prop {String} _mword - magic salt prefix
  * @prop {Function} _normalize - strings to NFKD form
  * @prop {Function} _pbkdf2 - the raw PBKDF2 function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashphrase",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashphrase",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "SEE LICENSE IN LICENSE"
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashphrase",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dashphrase",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "SEE LICENSE IN LICENSE"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashphrase",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Dash HD Wallet Passphrase generator. Secure, lightweight, BIP-39-compatible Base2048 mnemonic word lists. Works in Node, Bundlers, and Browsers.",
   "main": "dashphrase.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashphrase",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Dash HD Wallet Passphrase generator. Secure, lightweight, BIP-39-compatible Base2048 mnemonic word lists. Works in Node, Bundlers, and Browsers.",
   "main": "dashphrase.js",
   "browser": {


### PR DESCRIPTION
Originally we were supposed to check for words and checksum in `toSeed()`, but when it was copied over from the PBKDF2 wrapper, that was accidentally left out.

Now this properly checks the word list and the checksum before `toSeed(words, secret)` with an optional `{ verify: false }` for compatibility with non base2048 words, which were in use in some apps at some point...